### PR TITLE
サーバサイド】商品詳細表示

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :new, :create, :show]
+  before_action :set_item, only: [:show]
   def index
     @items = Item.all.order(created_at: "DESC").limit(3)
   end
@@ -21,7 +22,22 @@ class ItemsController < ApplicationController
   end
 
   def show
+    # @post_item_user = @item.user
+    @category = Category.find(@item.category_id)
+    # area = ShippingPrefecture.all.pluck(:name)
+    # @area = @item.area
+    # condition = ItemCondition.all.pluck(:name)
     
+    condition = ItemCondition.find(@item.item_condition_id)
+    @condition = condition.name
+    
+    postage_payer =  PostagePayer.find(@item.postage_payer_id)
+    @postage_payer = postage_payer.name
+    
+    shipping_day = ShippingDay.find(@item.shipping_day_id)
+    @shipping_day = shipping_day.name
+    
+ 
   end
 
   def item_params
@@ -32,4 +48,9 @@ class ItemsController < ApplicationController
   def move_to_index
     redirect_to action: :index unless user_signed_in?
   end
+
+  def set_item
+    @item = Item.find(params[:id])
+  end
+
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :move_to_index, except: [:index, :new, :create]
+  before_action :move_to_index, except: [:index, :new, :create, :show]
   def index
     @items = Item.all.order(created_at: "DESC").limit(3)
   end
@@ -18,6 +18,10 @@ class ItemsController < ApplicationController
       flash.now[:alert] = "投稿に失敗しました"
       render ("items/new")
     end
+  end
+
+  def show
+    
   end
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,6 +37,8 @@ class ItemsController < ApplicationController
     shipping_day = ShippingDay.find(@item.shipping_day_id)
     @shipping_day = shipping_day.name
     
+    shipping_prefecture = ShippingPrefecture.find(@item.shipping_prefecture_id)
+    @shipping_prefecture = shipping_prefecture.name
  
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,12 +22,8 @@ class ItemsController < ApplicationController
   end
 
   def show
-    # @post_item_user = @item.user
     @category = Category.find(@item.category_id)
-    # area = ShippingPrefecture.all.pluck(:name)
-    # @area = @item.area
-    # condition = ItemCondition.all.pluck(:name)
-    
+      
     condition = ItemCondition.find(@item.item_condition_id)
     @condition = condition.name
     
@@ -39,7 +35,6 @@ class ItemsController < ApplicationController
     
     shipping_prefecture = ShippingPrefecture.find(@item.shipping_prefecture_id)
     @shipping_prefecture = shipping_prefecture.name
- 
   end
 
   def item_params

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,6 +1,6 @@
 %ul
-  -# %li
-  -#   = @area
+  %li
+    =  @shipping_prefecture
   %li
     = image_tag @item.images[0].url.url
   %li

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,0 +1,31 @@
+%ul
+  -# %li
+  -#   = @area
+  %li
+    = image_tag @item.images[0].url.url
+  %li
+    = @category.name
+  %li
+    = @item.brand
+  %li
+    = @item.name
+  %li
+    = @item.introduction
+  %li
+    = @item.price
+  %li
+    = @postage_payer
+  %li
+    = @shipping_day
+  %li
+    = @item.trading_status
+  %li
+    = @condition
+
+-# -if(current_user.id == @item.user_id)
+-#   %li
+-#     = link_to '商品情報を編集する', '#' 
+-#   %li
+-#     = link_to '削除する', '#' 
+-#   %li
+-#     = link_to '購入画面に進む', '#'

--- a/app/views/top/_section4.html.haml
+++ b/app/views/top/_section4.html.haml
@@ -6,7 +6,7 @@
     .new__item__lists
       - @items.each do |item|
         .new__item__list
-          = link_to "#" do
+          = link_to item_path(item.id) do
             - item.images.each do |image|
               =image_tag image.url.url ,class: "new__item__image"
                 -# 売り切れた商品にはsoldを表示する条件分岐 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,5 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: "top#index"
   resources :users, only: :index
-  resources :items, only: [:new, :create]
+  resources :items, only: [:new, :create, :show]
 end


### PR DESCRIPTION
# What
items_controllerにshowアクションを追加し、出品時に入力した商品情報をviewに表示できるようにした。

具体的な作業として
showアクションには、以下のitemテーブルを元に記述を行った。
https://gyazo.com/3424e68b84fc46aeaecd046f24ba0111

# Why
出品時に入力した情報を商品詳細ページに表示させることで2点メリットがある。
1. 閲覧者は商品ついて詳しく知ることができる。
2. 出品者は出品時に入力した情報を参照できるため、商品詳細ページでにおける情報編集を容易にできる。

